### PR TITLE
feat: support content-type

### DIFF
--- a/custom_components/s3/__init__.py
+++ b/custom_components/s3/__init__.py
@@ -90,7 +90,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         key = call.data.get(KEY)
         file_path = call.data.get(FILE_PATH)
         storage_class = call.data.get(STORAGE_CLASS, "STANDARD")
-        content_type = call.data.get(CONTENT_TYPE, "binary/octet-stream")
+        content_type = call.data.get(CONTENT_TYPE)
 
         if storage_class not in STORAGE_CLASSES:
             _LOGGER.error("Invalid storage class %s", storage_class)
@@ -109,7 +109,10 @@ async def async_setup(hass: HomeAssistant, config: dict):
             return
 
         file_name = os.path.basename(file_path)
-        extra_args = {"StorageClass": storage_class, "ContentType": content_type}
+        extra_args = {"StorageClass": storage_class}
+        if content_type:
+          extra_args.update({"ContentType": content_type})
+          
         try:
             s3_client.upload_file(Filename=file_path, Bucket=bucket, Key=key, ExtraArgs=extra_args)
             _LOGGER.info(

--- a/custom_components/s3/__init__.py
+++ b/custom_components/s3/__init__.py
@@ -111,7 +111,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         file_name = os.path.basename(file_path)
         extra_args = {"StorageClass": storage_class}
         if content_type:
-          extra_args.update({"ContentType": content_type})
+            extra_args.update({"ContentType": content_type})
           
         try:
             s3_client.upload_file(Filename=file_path, Bucket=bucket, Key=key, ExtraArgs=extra_args)

--- a/custom_components/s3/__init__.py
+++ b/custom_components/s3/__init__.py
@@ -30,6 +30,7 @@ KEY = "key"
 KEY_DESTINATION = "key_destination"
 KEY_SOURCE = "key_source"
 STORAGE_CLASS = "storage_class"
+CONTENT_TYPE = "content_type"
 
 DEFAULT_REGION = "us-east-1"
 SUPPORTED_REGIONS = [
@@ -89,6 +90,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
         key = call.data.get(KEY)
         file_path = call.data.get(FILE_PATH)
         storage_class = call.data.get(STORAGE_CLASS, "STANDARD")
+        content_type = call.data.get(CONTENT_TYPE, "binary/octet-stream")
 
         if storage_class not in STORAGE_CLASSES:
             _LOGGER.error("Invalid storage class %s", storage_class)
@@ -107,7 +109,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
             return
 
         file_name = os.path.basename(file_path)
-        extra_args = {"StorageClass": storage_class}
+        extra_args = {"StorageClass": storage_class, "ContentType": content_type}
         try:
             s3_client.upload_file(Filename=file_path, Bucket=bucket, Key=key, ExtraArgs=extra_args)
             _LOGGER.info(


### PR DESCRIPTION
fixes #24 by adding support for Content-Type

Usage:
```
service: s3.put
data_template:
  bucket: xxxxxxx-doorbell
  key: "{{ trigger.event.data.file }}"
  file_path: "{{ trigger.event.data.path }}"
  storage_class: ONEZONE_IA
  content_type: image/jpeg
```