### PR TITLE
Fix typo in services.yaml

### DIFF
--- a/custom_components/s3/services.yaml
+++ b/custom_components/s3/services.yaml
@@ -51,7 +51,7 @@ put:
             - label: Glacier Deep Archive
               value: DEEP_ARCHIVE
             - label: Glacier, Instant Retrieval
-              value: GLACIER_IRcopy:
+              value: GLACIER_IR
 copy:
   name: Copy file
   description: Copy file from one location in s3 to another.


### PR DESCRIPTION
PR #35 introduced a typo that broke the `services.yaml` file.

This PR fixes it.