### PR TITLE
Fix async_unload_entry

### DIFF
--- a/custom_components/s3/__init__.py
+++ b/custom_components/s3/__init__.py
@@ -249,8 +249,5 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    hass.data[DOMAIN].remove(entry.entry_id)
-
-    if not hass.data[DOMAIN]:
-        hass.services.async_remove(DOMAIN, PUT_SERVICE)
+    hass.data[DOMAIN].pop(entry.entry_id, None)
     return True


### PR DESCRIPTION
Fix wrong dict method call for entry removal in `async_unload_entry`. Do not remove `s3.put` service if we are just removing an entity.