### PR TITLE
Fix blocking call when initializing entry

### DIFF
--- a/custom_components/s3/__init__.py
+++ b/custom_components/s3/__init__.py
@@ -236,15 +236,18 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
-    import boto3
-
     aws_config = {
         CONF_REGION: entry.data[CONF_REGION],
         CONF_ACCESS_KEY_ID: entry.data[CONF_ACCESS_KEY_ID],
         CONF_SECRET_ACCESS_KEY: entry.data[CONF_SECRET_ACCESS_KEY],
     }
-    client = boto3.client("s3", **aws_config)  # Will not raise error.
+
+    def boto_client(self, aws_config):
+        return boto3.client("s3", **aws_config)  # Will not raise error.
+
+    client = await hass.async_add_executor_job(boto_client, aws_config)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+
     return True
 
 


### PR DESCRIPTION
Wraps up `boto3.client` call to not block Home Assistant initialization (`boto3.client` does a blockign call to `os.listdir`).

This also fixes the relevant warning.